### PR TITLE
Setting yaml files to public after copying them

### DIFF
--- a/.github/workflows/copy-to-s3.yaml
+++ b/.github/workflows/copy-to-s3.yaml
@@ -21,11 +21,19 @@ jobs:
     - name: Get the version of the just published release
       id: get_version
       run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-    - name: Copy ${{ env.FILE_TO_COPY_1 }}.yaml to S3
-      run: aws s3 cp ${{ env.FILE_TO_COPY_1 }}.yaml s3://${{ secrets.SENZING_AWS_MARKETPLACE_BUCKET_NAME }}/basic/${{ env.FILE_TO_COPY_1 }}.yaml
-    - name: Copy ${{ env.FILE_TO_COPY_1 }}.yaml to S3 with version number
-      run: aws s3 cp ${{ env.FILE_TO_COPY_1 }}.yaml s3://${{ secrets.SENZING_AWS_MARKETPLACE_BUCKET_NAME }}/basic/${{ env.FILE_TO_COPY_1 }}-${{ steps.get_version.outputs.VERSION }}.yaml
-    - name: Copy ${{ env.FILE_TO_COPY_2 }}.yaml to S3
-      run: aws s3 cp ${{ env.FILE_TO_COPY_2 }}.yaml s3://${{ secrets.SENZING_AWS_MARKETPLACE_BUCKET_NAME }}/database/${{ env.FILE_TO_COPY_2 }}.yaml
-    - name: Copy ${{ env.FILE_TO_COPY_2 }} to S3 with version number
-      run: aws s3 cp ${{ env.FILE_TO_COPY_2 }}.yaml s3://${{ secrets.SENZING_AWS_MARKETPLACE_BUCKET_NAME }}/database/${{ env.FILE_TO_COPY_2 }}-${{ steps.get_version.outputs.VERSION }}.yaml
+    - name: Copy ${{ env.FILE_TO_COPY_1 }}.yaml to S3 and make it public
+      run: |
+           aws s3 cp ${{ env.FILE_TO_COPY_1 }}.yaml s3://${{ secrets.SENZING_AWS_MARKETPLACE_BUCKET_NAME }}/basic/${{ env.FILE_TO_COPY_1 }}.yaml
+           aws s3api put-object-acl --bucket ${{ secrets.SENZING_AWS_MARKETPLACE_BUCKET_NAME }} --key basic/${{ env.FILE_TO_COPY_1 }}.yaml --acl public-read
+    - name: Copy ${{ env.FILE_TO_COPY_1 }}.yaml to S3 with version number and make it public
+      run: |
+           aws s3 cp ${{ env.FILE_TO_COPY_1 }}.yaml s3://${{ secrets.SENZING_AWS_MARKETPLACE_BUCKET_NAME }}/basic/${{ env.FILE_TO_COPY_1 }}-${{ steps.get_version.outputs.VERSION }}.yaml
+           aws s3api put-object-acl --bucket ${{ secrets.SENZING_AWS_MARKETPLACE_BUCKET_NAME }} --key basic/${{ env.FILE_TO_COPY_1 }}-${{ steps.get_version.outputs.VERSION }}.yaml --acl public-read
+    - name: Copy ${{ env.FILE_TO_COPY_2 }}.yaml to S3 and make it public
+      run: |
+           aws s3 cp ${{ env.FILE_TO_COPY_2 }}.yaml s3://${{ secrets.SENZING_AWS_MARKETPLACE_BUCKET_NAME }}/database/${{ env.FILE_TO_COPY_2 }}.yaml
+           aws s3api put-object-acl --bucket ${{ secrets.SENZING_AWS_MARKETPLACE_BUCKET_NAME }} --key database/${{ env.FILE_TO_COPY_2 }}.yaml --acl public-read
+    - name: Copy ${{ env.FILE_TO_COPY_2 }} to S3 with version number and make it public
+      run: |
+           aws s3 cp ${{ env.FILE_TO_COPY_2 }}.yaml s3://${{ secrets.SENZING_AWS_MARKETPLACE_BUCKET_NAME }}/database/${{ env.FILE_TO_COPY_2 }}-${{ steps.get_version.outputs.VERSION }}.yaml
+           aws s3api put-object-acl --bucket ${{ secrets.SENZING_AWS_MARKETPLACE_BUCKET_NAME }} --key database/${{ env.FILE_TO_COPY_2 }}-${{ steps.get_version.outputs.VERSION }}.yaml --acl public-read


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

Issue number: #77 

## Why was change needed

The yaml file needs to be public after copying up to s3

## What does change improve

Makes them public
